### PR TITLE
fix: use OAuth 2.0 token endpoint to fix the "captcha_required" login error

### DIFF
--- a/internal/pikpak/pikpak.go
+++ b/internal/pikpak/pikpak.go
@@ -60,16 +60,16 @@ func NewPikPak(account, password string) PikPak {
 
 func (p *PikPak) Login() error {
 	m := make(map[string]string)
-	m["captcha_token"] = ""
 	m["client_id"] = clientID
 	m["client_secret"] = clientSecret
+	m["grant_type"] = "password"
 	m["username"] = p.Account
 	m["password"] = p.Password
 	bs, err := jsoniter.Marshal(&m)
 	if err != nil {
 		return err
 	}
-	req, err := http.NewRequest("POST", "https://user.mypikpak.com/v1/auth/signin?client_id="+clientID, bytes.NewBuffer(bs))
+	req, err := http.NewRequest("POST", "https://user.mypikpak.com/v1/auth/token", bytes.NewBuffer(bs))
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Fix #32 with https://github.com/alist-org/alist/issues/6493#issuecomment-2125479904.