### PR TITLE
feat: add -n option for task name specification

### DIFF
--- a/cmd/new/url/url.go
+++ b/cmd/new/url/url.go
@@ -59,6 +59,8 @@ var path string
 
 var parentId string
 
+var name string
+
 var input string
 
 var cli bool
@@ -66,6 +68,7 @@ var cli bool
 func init() {
 	NewUrlCommand.Flags().StringVarP(&path, "path", "p", "/", "The path of the folder")
 	NewUrlCommand.Flags().StringVarP(&parentId, "parent-id", "P", "", "The parent id")
+	NewUrlCommand.Flags().StringVarP(&name, "name", "n", "", "The name of the task")
 	NewUrlCommand.Flags().StringVarP(&input, "input", "i", "", "The input of the sha file")
 	NewUrlCommand.Flags().BoolVarP(&cli, "cli", "c", false, "The cli mode")
 }
@@ -81,7 +84,7 @@ func handleNewUrl(p *pikpak.PikPak, shas []string) {
 		}
 	}
 	for _, url := range shas {
-		err := p.CreateUrlFile(parentId, url)
+		err := p.CreateUrlFile(parentId, url, name)
 		if err != nil {
 			logrus.Errorln("Create url file failed: ", err)
 			continue
@@ -108,7 +111,7 @@ func handleCli(p *pikpak.PikPak) {
 			break
 		}
 		url := string(lineBytes)
-		err = p.CreateUrlFile(parentId, url)
+		err = p.CreateUrlFile(parentId, url, name)
 		if err != nil {
 			logrus.Errorln("Create url file failed: ", err)
 			continue

--- a/internal/pikpak/url.go
+++ b/internal/pikpak/url.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func (p *PikPak) CreateUrlFile(parentId, url string) error {
+func (p *PikPak) CreateUrlFile(parentId, url string, name string) error {
 	m := map[string]interface{}{
 		"kind":        "drive#file",
 		"upload_type": "UPLOAD_TYPE_URL",
@@ -19,6 +19,9 @@ func (p *PikPak) CreateUrlFile(parentId, url string) error {
 	}
 	if parentId != "" {
 		m["parent_id"] = parentId
+	}
+	if name != "" {
+		m["name"] = name
 	}
 	bs, err := jsoniter.Marshal(&m)
 	if err != nil {


### PR DESCRIPTION
新增添加离线任务时，指定任务名。在 `new url` 子命令中通过 `-n` 指定。

例如：`pikpakcli.exe new url -n "Boom Town(1940)" -p /Movies 'magnet:?xt=urn:btih:42D689298C519F1CDAB5CE6BF5F6BE99468E1DDB'`

任务原名是 `Boom.Town.1940.1080p.WEBRip.x265-RARBG`，没指定任务名时，下载将会保存到 `/Movies/Boom.Town.1940.1080p.WEBRip.x265-RARBG` 中。指定后下载内容保存路径变为 `/Movies/Boom Town(1940)` 。