### PR TITLE
Add delete command for removing files from PikPak server

### DIFF
--- a/cmd/del/del.go
+++ b/cmd/del/del.go
@@ -1,0 +1,61 @@
+package delete
+
+import (
+	"github.com/52funny/pikpakcli/conf"
+	"github.com/52funny/pikpakcli/internal/pikpak"
+	"github.com/sirupsen/logrus"
+	"github.com/spf13/cobra"
+)
+
+var path string
+var err error
+var parentId string
+
+var DeleteCmd = &cobra.Command{
+	Use:   "delete [filename]",
+	Short: "Delete a file or folder on the PikPak server",
+	Run: func(cmd *cobra.Command, args []string) {
+		if len(args) == 0 {
+			logrus.Error("Please provide a file name to delete")
+			return
+		}
+
+		p := pikpak.NewPikPak(conf.Config.Username, conf.Config.Password)
+		if err := p.Login(); err != nil {
+			logrus.Fatalf("Login Failed: %v", err)
+			return
+		}
+
+		parentId, err = p.GetPathFolderId(path)
+		if err != nil {
+			logrus.Errorln("get path folder id error:", err)
+			return
+		}
+
+		files, err := p.GetFolderFileStatList(parentId)
+
+		for _, targetName := range args {
+			found := false
+			for _, f := range files {
+				if f.Name == targetName {
+					logrus.Debugf("Matched file: Name=%s, ID=%s, Size=%d", f.Name, f.ID, f.Size)
+					err = p.DeleteFile(f.ID)
+					if err != nil {
+						logrus.Errorf("Failed to delete %s: %v", f.Name, err)
+					} else {
+						logrus.Infof("Deleted: %s", f.Name)
+					}
+					found = true
+					break
+				}
+			}
+			if !found {
+				logrus.Errorf("File not found in %s: %s", path, targetName)
+			}
+		}
+	},
+}
+
+func init() {
+	DeleteCmd.Flags().StringVarP(&path, "path", "p", "/", "The path where to look for the file")
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -10,7 +10,7 @@ import (
 	"github.com/52funny/pikpakcli/cmd/quota"
 	"github.com/52funny/pikpakcli/cmd/share"
 	"github.com/52funny/pikpakcli/cmd/upload"
-
+	del "github.com/52funny/pikpakcli/cmd/del"
 	"github.com/52funny/pikpakcli/conf"
 	"github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
@@ -53,6 +53,7 @@ func init() {
 	rootCmd.AddCommand(embed.EmbedCmd)
 	rootCmd.AddCommand(quota.QuotaCmd)
 	rootCmd.AddCommand(list.ListCmd)
+	rootCmd.AddCommand(del.DeleteCmd)
 }
 
 // Execute the command line interface

--- a/docs/command.md
+++ b/docs/command.md
@@ -121,3 +121,23 @@
   ```bash
   pikpakcli ls -lH -p /
   ```
+  
+## Delete
+
+- Delete a file by full path from the PikPak cloud.
+
+  ```bash
+  pikpakcli delete Movies/Peppa_Pig.mp4
+  ```
+
+- Delete a file from a specific directory using the `-p` flag.
+
+  ```bash
+  pikpakcli delete -p Movies Peppa_Pig.mp4
+  ```
+
+- Delete multiple files under the same path.
+
+  ```bash
+  pikpakcli delete -p Movies File1.mp4 File2.mp4
+  ```

--- a/docs/command_zhCN.md
+++ b/docs/command_zhCN.md
@@ -120,3 +120,23 @@
   ```bash
   pikpakcli ls -lH -p /
   ```
+
+## 删除
+
+- 删除指定文件
+
+  ```bash
+  pikpakcli delete Movies/Peppa_Pig.mp4
+  ```
+
+- 删除指定目录中的文件
+
+  ```bash
+  pikpakcli delete -p 文件夹路径 文件名
+  ```
+
+- 同时删除多个文件
+
+  ```bash
+  pikpakcli delete -p 文件夹路径 文件1 文件2
+  ```

--- a/internal/pikpak/file.go
+++ b/internal/pikpak/file.go
@@ -173,3 +173,21 @@ func (p *PikPak) GetFile(fileId string) (File, error) {
 	}
 	return fileInfo, err
 }
+
+func (p *PikPak) DeleteFile(fileId string) error {
+	req, err := http.NewRequest("DELETE", "https://api-drive.mypikpak.com/drive/v1/files/"+fileId, nil)
+	if err != nil {
+		return err
+	}
+	req.Header.Set("X-Captcha-Token", p.CaptchaToken)
+	req.Header.Set("X-Device-Id", p.DeviceId)
+	bs, err := p.sendRequest(req)
+	if err != nil {
+		return err
+	}
+	error_code := gjson.Get(*(*string)(unsafe.Pointer(&bs)), "error_code").Int()
+	if error_code != 0 {
+		return errors.New(gjson.Get(*(*string)(unsafe.Pointer(&bs)), "error").String() + ":" + fileId)
+	}
+	return nil
+}


### PR DESCRIPTION
This PR adds a new delete command to the CLI, allowing users to delete specific files from the PikPak server by name. It supports path-based targeting using the --path flag to locate the correct parent folder. It also includes appropriate error handling and debug logging.

Also includes:
• Command documentation in both English and Chinese to describe usage and flags.