### PR TITLE
Fix: behavior issues with the download and upload commands in the interactive shell.

### DIFF
--- a/cli/download/download.go
+++ b/cli/download/download.go
@@ -82,6 +82,14 @@ type downloadTargetResolver interface {
 }
 
 func handleDownload(cmd *cobra.Command, p *api.PikPak, args []string) {
+	// Reset global variables to defaults if flags not explicitly set
+	if !cmd.Flags().Changed("path") {
+		folder = "/"
+	}
+	if !cmd.Flags().Changed("parent-id") {
+		parentId = ""
+	}
+
 	if err := utils.CreateDirIfNotExist(output); err != nil {
 		fmt.Println("Create output directory failed")
 		logx.Error(err)
@@ -109,7 +117,7 @@ func handleDownload(cmd *cobra.Command, p *api.PikPak, args []string) {
 }
 
 func shouldShowDownloadHelp(cmd *cobra.Command, args []string) bool {
-	return len(args) == 0 && !cmd.Flags().Changed("path") && !cmd.Flags().Changed("parent-id")
+	return len(args) == 0
 }
 
 func requiresExplicitOutputFlag(cmd *cobra.Command, args []string) bool {
@@ -126,6 +134,12 @@ func requiresExplicitOutputFlag(cmd *cobra.Command, args []string) bool {
 }
 
 func downloadTarget(p *api.PikPak, arg string) {
+	if arg == "*" {
+		// Download all files in current directory (non-recursive)
+		downloadFilesInCurrentDir(p)
+		return
+	}
+
 	stat, err := resolveDownloadTarget(p, arg)
 	if err != nil {
 		target := remoteTargetPath(arg)
@@ -145,6 +159,44 @@ func downloadTarget(p *api.PikPak, arg string) {
 			output: output,
 		},
 	})
+}
+
+func downloadFilesInCurrentDir(p *api.PikPak) {
+	parentID := ""
+	var err error
+	if folder != "/" {
+		parentID, err = p.GetPathFolderId(folder)
+		if err != nil {
+			fmt.Println("Get current directory failed")
+			logx.Error(err)
+			return
+		}
+	}
+
+	files, err := p.GetFolderFileStatList(parentID)
+	if err != nil {
+		fmt.Println("Get folder file list failed")
+		logx.Error(err)
+		return
+	}
+
+	var warpFiles []warpFile
+	for _, file := range files {
+		if file.Kind == api.FileKindFile {
+			f, err := p.GetFile(file.ID)
+			if err != nil {
+				fmt.Println("Get file failed:", file.Name)
+				logx.Error(err)
+				continue
+			}
+			warpFiles = append(warpFiles, warpFile{
+				f:      &f,
+				output: output,
+			})
+		}
+	}
+
+	downloadFiles(p, warpFiles)
 }
 
 func downloadFolder(p *api.PikPak, folderID string, rootOutput string) {

--- a/cli/download/download.go
+++ b/cli/download/download.go
@@ -341,6 +341,14 @@ func resolveDownloadTarget(p downloadTargetResolver, arg string) (api.FileStat, 
 		return p.GetFileByPath(remotePath)
 	}
 
+	// Handle glob patterns by removing them
+	if strings.Contains(arg, "*") {
+		arg = strings.Split(arg, "*")[0]
+		if arg == "" {
+			return api.FileStat{}, fmt.Errorf("invalid path with glob pattern")
+		}
+	}
+
 	if parentId != "" && !filepath.IsAbs(arg) && !strings.Contains(arg, string(filepath.Separator)) {
 		return p.GetFileStat(parentId, arg)
 	}

--- a/cli/download/download.go
+++ b/cli/download/download.go
@@ -83,11 +83,17 @@ type downloadTargetResolver interface {
 
 func handleDownload(cmd *cobra.Command, p *api.PikPak, args []string) {
 	// Reset global variables to defaults if flags not explicitly set
-	if !cmd.Flags().Changed("path") {
+	pathValue, _ := cmd.Flags().GetString("path")
+	if pathValue == "/" {
 		folder = "/"
+	} else {
+		folder = pathValue
 	}
-	if !cmd.Flags().Changed("parent-id") {
+	parentIdValue, _ := cmd.Flags().GetString("parent-id")
+	if parentIdValue == "" {
 		parentId = ""
+	} else {
+		parentId = parentIdValue
 	}
 
 	if err := utils.CreateDirIfNotExist(output); err != nil {
@@ -107,7 +113,13 @@ func handleDownload(cmd *cobra.Command, p *api.PikPak, args []string) {
 	}
 
 	if len(args) == 0 {
-		downloadTarget(p, "")
+		pathValue, _ := cmd.Flags().GetString("path")
+		if pathValue != "/" {
+			// When -p is specified but no positional args, download the path
+			downloadTarget(p, ".")
+		} else {
+			downloadTarget(p, "")
+		}
 		return
 	}
 
@@ -117,7 +129,9 @@ func handleDownload(cmd *cobra.Command, p *api.PikPak, args []string) {
 }
 
 func shouldShowDownloadHelp(cmd *cobra.Command, args []string) bool {
-	return len(args) == 0
+	pathValue, _ := cmd.Flags().GetString("path")
+	parentIdValue, _ := cmd.Flags().GetString("parent-id")
+	return len(args) == 0 && pathValue == "/" && parentIdValue == ""
 }
 
 func requiresExplicitOutputFlag(cmd *cobra.Command, args []string) bool {

--- a/cli/download/download.go
+++ b/cli/download/download.go
@@ -93,6 +93,11 @@ func handleDownload(cmd *cobra.Command, p *api.PikPak, args []string) {
 		return
 	}
 
+	if shouldShowDownloadHelp(cmd, args) {
+		cmd.Help()
+		return
+	}
+
 	if len(args) == 0 {
 		downloadTarget(p, "")
 		return
@@ -101,6 +106,10 @@ func handleDownload(cmd *cobra.Command, p *api.PikPak, args []string) {
 	for _, arg := range args {
 		downloadTarget(p, arg)
 	}
+}
+
+func shouldShowDownloadHelp(cmd *cobra.Command, args []string) bool {
+	return len(args) == 0 && !cmd.Flags().Changed("path") && !cmd.Flags().Changed("parent-id")
 }
 
 func requiresExplicitOutputFlag(cmd *cobra.Command, args []string) bool {

--- a/cli/upload/upload.go
+++ b/cli/upload/upload.go
@@ -46,6 +46,10 @@ var UploadCmd = &cobra.Command{
 				}
 			}
 		}()
+		if len(args) == 0 {
+			cmd.Help()
+			return
+		}
 		for _, v := range args {
 			v = utils.ExpandLocalPath(v)
 			stat, err := os.Stat(v)

--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -460,13 +460,23 @@ func adaptShellArgs(rootCmd *cobra.Command, currentPath string, args []string) [
 		if !flags.hasPath && !flags.hasParentID && flags.positionals > 0 {
 			rest = append([]string{"-p", currentPath}, rest...)
 		}
-		// Handle glob patterns like "*" for download
-		if commandKey == "download" {
-			for i, arg := range rest {
-				if arg == "*" {
-					rest[i] = "."
+		// Handle glob patterns for upload (local paths)
+		if commandKey == "upload" {
+			expandedRest := make([]string, 0, len(rest))
+			for _, arg := range rest {
+				if strings.Contains(arg, "*") {
+					// Expand glob pattern for local files
+					matches, err := filepath.Glob(utils.ExpandLocalPath(arg))
+					if err == nil && len(matches) > 0 {
+						expandedRest = append(expandedRest, matches...)
+					} else {
+						expandedRest = append(expandedRest, arg)
+					}
+				} else {
+					expandedRest = append(expandedRest, arg)
 				}
 			}
+			rest = expandedRest
 		}
 	case "delete":
 		if !flags.hasPath {

--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -457,7 +457,7 @@ func adaptShellArgs(rootCmd *cobra.Command, currentPath string, args []string) [
 		}
 	case "download", "share", "upload", "new folder", "new url", "new sha":
 		rest = rewritePathFlagValues(rest, currentPath)
-		if !flags.hasPath && !flags.hasParentID {
+		if flags.hasPath || flags.hasParentID || flags.positionals > 0 {
 			rest = append([]string{"-p", currentPath}, rest...)
 		}
 	case "delete":

--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -457,8 +457,16 @@ func adaptShellArgs(rootCmd *cobra.Command, currentPath string, args []string) [
 		}
 	case "download", "share", "upload", "new folder", "new url", "new sha":
 		rest = rewritePathFlagValues(rest, currentPath)
-		if flags.hasPath || flags.hasParentID || flags.positionals > 0 {
+		if !flags.hasPath && !flags.hasParentID && flags.positionals > 0 {
 			rest = append([]string{"-p", currentPath}, rest...)
+		}
+		// Handle glob patterns like "*" for download
+		if commandKey == "download" {
+			for i, arg := range rest {
+				if arg == "*" {
+					rest[i] = "."
+				}
+			}
 		}
 	case "delete":
 		if !flags.hasPath {

--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -454,6 +454,7 @@ func TestAdaptShellArgs(t *testing.T) {
 		{name: "download keeps trailing dot as positional target", args: []string{"download", "-g", "episode.mkv", "."}, want: []string{"download", "-p", "/Movies", "-g", "episode.mkv", "."}},
 		{name: "share injects current path", args: []string{"share", "episode.mkv"}, want: []string{"share", "-p", "/Movies", "episode.mkv"}},
 		{name: "upload injects current path", args: []string{"upload", "local.file"}, want: []string{"upload", "-p", "/Movies", "local.file"}},
+		{name: "upload supports glob star", args: []string{"upload", "*"}, want: []string{"upload", "-p", "/Movies", "open.go", "shell.go", "shell_test.go"}},
 		{name: "delete rewrites relative args", args: []string{"delete", "a", "b/c"}, want: []string{"delete", "/Movies/a", "/Movies/b/c"}},
 		{name: "rm alias rewrites relative args", args: []string{"rm", "a", "b/c"}, want: []string{"rm", "/Movies/a", "/Movies/b/c"}},
 		{name: "rename rewrites first arg only", args: []string{"rename", "old.txt", "new.txt"}, want: []string{"rename", "/Movies/old.txt", "new.txt"}},

--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -448,6 +448,7 @@ func TestAdaptShellArgs(t *testing.T) {
 		{name: "ls rewrites relative arg", args: []string{"ls", "Kids"}, want: []string{"ls", "/Movies/Kids"}},
 		{name: "empty rewrites relative arg", args: []string{"empty", "Kids"}, want: []string{"empty", "/Movies/Kids"}},
 		{name: "rubbish keeps local rules path and rewrites remote root", args: []string{"rubbish", "--rules", "~/Library/Application Support/pikpakcli/rules/rubbish_rules.txt", "/"}, want: []string{"rubbish", "--rules", "~/Library/Application Support/pikpakcli/rules/rubbish_rules.txt", "/"}},
+		{name: "download no args doesn't inject current path", args: []string{"download"}, want: []string{"download"}},
 		{name: "download injects current path", args: []string{"download", "episode.mkv"}, want: []string{"download", "-p", "/Movies", "episode.mkv"}},
 		{name: "download rewrites relative path flag", args: []string{"download", "-p", "Kids", "episode.mkv"}, want: []string{"download", "-p", "/Movies/Kids", "episode.mkv"}},
 		{name: "download keeps trailing dot as positional target", args: []string{"download", "-g", "episode.mkv", "."}, want: []string{"download", "-p", "/Movies", "-g", "episode.mkv", "."}},


### PR DESCRIPTION
修复了 download 和 upload 命令问题：
1. download 命令无参数时下载整个目录：当用户直接输入 download，无任何参数下，会下载当前目录下的所有文件。目前改成了显示 download 的 help 信息。
2. upload 命令无参数时无返回信息。目前改成了显示 upload 的 help 信息。
3. download 现在支持通配符 `*`

修复了 download 和 upload 在交互式shell中的问题：
1. download 现在在shell中支持通配符  `*`
2. upload 现在在 shell 中支持通配符 `*`

已知问题：
- 目前 download 在命令下 (./pickpak download ...) 不支持通配符