### PR TITLE
Feat: Add find command to search files in user's Pikpak library

### DIFF
--- a/cli/download/download.go
+++ b/cli/download/download.go
@@ -82,6 +82,14 @@ type downloadTargetResolver interface {
 }
 
 func handleDownload(cmd *cobra.Command, p *api.PikPak, args []string) {
+	// Reset global variables to defaults if flags not explicitly set
+	if !cmd.Flags().Changed("path") {
+		folder = "/"
+	}
+	if !cmd.Flags().Changed("parent-id") {
+		parentId = ""
+	}
+
 	if err := utils.CreateDirIfNotExist(output); err != nil {
 		fmt.Println("Create output directory failed")
 		logx.Error(err)
@@ -109,7 +117,7 @@ func handleDownload(cmd *cobra.Command, p *api.PikPak, args []string) {
 }
 
 func shouldShowDownloadHelp(cmd *cobra.Command, args []string) bool {
-	return len(args) == 0 && !cmd.Flags().Changed("path") && !cmd.Flags().Changed("parent-id")
+	return len(args) == 0
 }
 
 func requiresExplicitOutputFlag(cmd *cobra.Command, args []string) bool {
@@ -126,6 +134,12 @@ func requiresExplicitOutputFlag(cmd *cobra.Command, args []string) bool {
 }
 
 func downloadTarget(p *api.PikPak, arg string) {
+	if arg == "*" {
+		// Download all files in current directory (non-recursive)
+		downloadFilesInCurrentDir(p)
+		return
+	}
+
 	stat, err := resolveDownloadTarget(p, arg)
 	if err != nil {
 		target := remoteTargetPath(arg)
@@ -145,6 +159,44 @@ func downloadTarget(p *api.PikPak, arg string) {
 			output: output,
 		},
 	})
+}
+
+func downloadFilesInCurrentDir(p *api.PikPak) {
+	parentID := ""
+	var err error
+	if folder != "/" {
+		parentID, err = p.GetPathFolderId(folder)
+		if err != nil {
+			fmt.Println("Get current directory failed")
+			logx.Error(err)
+			return
+		}
+	}
+
+	files, err := p.GetFolderFileStatList(parentID)
+	if err != nil {
+		fmt.Println("Get folder file list failed")
+		logx.Error(err)
+		return
+	}
+
+	var warpFiles []warpFile
+	for _, file := range files {
+		if file.Kind == api.FileKindFile {
+			f, err := p.GetFile(file.ID)
+			if err != nil {
+				fmt.Println("Get file failed:", file.Name)
+				logx.Error(err)
+				continue
+			}
+			warpFiles = append(warpFiles, warpFile{
+				f:      &f,
+				output: output,
+			})
+		}
+	}
+
+	downloadFiles(p, warpFiles)
 }
 
 func downloadFolder(p *api.PikPak, folderID string, rootOutput string) {

--- a/cli/download/download.go
+++ b/cli/download/download.go
@@ -341,6 +341,14 @@ func resolveDownloadTarget(p downloadTargetResolver, arg string) (api.FileStat, 
 		return p.GetFileByPath(remotePath)
 	}
 
+	// Handle glob patterns by removing them
+	if strings.Contains(arg, "*") {
+		arg = strings.Split(arg, "*")[0]
+		if arg == "" {
+			return api.FileStat{}, fmt.Errorf("invalid path with glob pattern")
+		}
+	}
+
 	if parentId != "" && !filepath.IsAbs(arg) && !strings.Contains(arg, string(filepath.Separator)) {
 		return p.GetFileStat(parentId, arg)
 	}

--- a/cli/download/download.go
+++ b/cli/download/download.go
@@ -83,11 +83,17 @@ type downloadTargetResolver interface {
 
 func handleDownload(cmd *cobra.Command, p *api.PikPak, args []string) {
 	// Reset global variables to defaults if flags not explicitly set
-	if !cmd.Flags().Changed("path") {
+	pathValue, _ := cmd.Flags().GetString("path")
+	if pathValue == "/" {
 		folder = "/"
+	} else {
+		folder = pathValue
 	}
-	if !cmd.Flags().Changed("parent-id") {
+	parentIdValue, _ := cmd.Flags().GetString("parent-id")
+	if parentIdValue == "" {
 		parentId = ""
+	} else {
+		parentId = parentIdValue
 	}
 
 	if err := utils.CreateDirIfNotExist(output); err != nil {
@@ -107,7 +113,13 @@ func handleDownload(cmd *cobra.Command, p *api.PikPak, args []string) {
 	}
 
 	if len(args) == 0 {
-		downloadTarget(p, "")
+		pathValue, _ := cmd.Flags().GetString("path")
+		if pathValue != "/" {
+			// When -p is specified but no positional args, download the path
+			downloadTarget(p, ".")
+		} else {
+			downloadTarget(p, "")
+		}
 		return
 	}
 
@@ -117,7 +129,9 @@ func handleDownload(cmd *cobra.Command, p *api.PikPak, args []string) {
 }
 
 func shouldShowDownloadHelp(cmd *cobra.Command, args []string) bool {
-	return len(args) == 0
+	pathValue, _ := cmd.Flags().GetString("path")
+	parentIdValue, _ := cmd.Flags().GetString("parent-id")
+	return len(args) == 0 && pathValue == "/" && parentIdValue == ""
 }
 
 func requiresExplicitOutputFlag(cmd *cobra.Command, args []string) bool {

--- a/cli/download/download.go
+++ b/cli/download/download.go
@@ -93,6 +93,11 @@ func handleDownload(cmd *cobra.Command, p *api.PikPak, args []string) {
 		return
 	}
 
+	if shouldShowDownloadHelp(cmd, args) {
+		cmd.Help()
+		return
+	}
+
 	if len(args) == 0 {
 		downloadTarget(p, "")
 		return
@@ -101,6 +106,10 @@ func handleDownload(cmd *cobra.Command, p *api.PikPak, args []string) {
 	for _, arg := range args {
 		downloadTarget(p, arg)
 	}
+}
+
+func shouldShowDownloadHelp(cmd *cobra.Command, args []string) bool {
+	return len(args) == 0 && !cmd.Flags().Changed("path") && !cmd.Flags().Changed("parent-id")
 }
 
 func requiresExplicitOutputFlag(cmd *cobra.Command, args []string) bool {

--- a/cli/find/find.go
+++ b/cli/find/find.go
@@ -1,0 +1,168 @@
+package find
+
+import (
+	"fmt"
+	"strconv"
+	"strings"
+
+	"github.com/52funny/pikpakcli/conf"
+	"github.com/52funny/pikpakcli/internal/api"
+	"github.com/spf13/cobra"
+)
+
+// Register the command
+var FindCmd = &cobra.Command{
+	Use:     "find",
+	Aliases: []string{"f"},
+	Short:   "Find files on PikPak",
+	Long:    `Find files and folders on PikPak using keywords`,
+	Run: func(cmd *cobra.Command, args []string) {
+		p := api.NewPikPakWithContext(cmd.Context(), conf.Config.Username, conf.Config.Password)
+		err := p.Login()
+		if err != nil {
+			fmt.Println("Login failed")
+			return
+		}
+		handleFind(cmd, &p, args)
+	},
+}
+
+// Flags
+var (
+	limit         int
+	humanFlag     bool
+	detailFlag    bool
+	pathFlag      string
+	recursiveFlag bool
+)
+
+func init() {
+	// Define flags
+	// Limit number of results
+	FindCmd.Flags().IntVarP(&limit, "limit", "l", 50, "Maximum number of results to return")
+	// Human readable file sizes
+	FindCmd.Flags().BoolVarP(&humanFlag, "human", "H", false, "Print human readable file sizes")
+	// Return in long format
+	FindCmd.Flags().BoolVarP(&detailFlag, "detail", "d", false, "Print detailed information (ID, size, modified time)")
+	// Search path
+	FindCmd.Flags().StringVarP(&pathFlag, "path", "p", "/", "Search path (default: /)")
+	// Recursive search
+	FindCmd.Flags().BoolVarP(&recursiveFlag, "recursive", "r", false, "Recursively search in subdirectories")
+}
+
+func handleFind(cmd *cobra.Command, p *api.PikPak, args []string) {
+	var phrase, searchPath string
+
+	// Parse arguments
+	if len(args) == 0 {
+		fmt.Println("Error: search phrase is required")
+		cmd.Usage()
+		return
+	} else if len(args) == 1 {
+		// Only one argument: it's the phrase
+		phrase = args[0]
+		searchPath = pathFlag
+	} else if len(args) == 2 {
+		// Two arguments: first is path, second is phrase
+		searchPath = args[0]
+		phrase = args[1]
+	} else {
+		fmt.Println("Error: too many arguments")
+		cmd.Usage()
+		return
+	}
+
+	// Normalize path: ensure starts with /, remove trailing /
+	if !strings.HasPrefix(searchPath, "/") {
+		searchPath = "/" + searchPath
+	}
+	// Remove trailing slash (except for root)
+	if searchPath != "/" && strings.HasSuffix(searchPath, "/") {
+		searchPath = strings.TrimSuffix(searchPath, "/")
+	}
+
+	var results []api.SearchResult
+	var err error
+
+	// Use recursive or non-recursive search based on flag
+	if recursiveFlag {
+		results, err = p.SearchFiles(phrase, limit)
+	} else {
+		results, err = p.SearchFilesInPath(phrase, searchPath, limit)
+	}
+
+	if err != nil {
+		fmt.Printf("Find failed: %v\n", err)
+		return
+	}
+
+	// Filter results by search path (only needed for recursive search)
+	var filteredResults []api.SearchResult
+	if recursiveFlag {
+		for _, result := range results {
+			// Check if result is under the search path
+			var isUnderPath bool
+			if searchPath == "/" {
+				// All results are under root
+				isUnderPath = true
+			} else if result.Path == searchPath {
+				// Exact match
+				isUnderPath = true
+			} else if strings.HasPrefix(result.Path, searchPath+"/") {
+				// Under the search path
+				isUnderPath = true
+			}
+			if isUnderPath {
+				filteredResults = append(filteredResults, result)
+			}
+		}
+	} else {
+		// Non-recursive search already filters by path
+		filteredResults = results
+	}
+
+	if len(filteredResults) == 0 {
+		fmt.Printf("No files found for phrase: %s in path: %s\n", phrase, searchPath)
+		return
+	}
+
+	if !detailFlag {
+		fmt.Printf("Find results for '%s' in '%s' (%d results):\n\n", phrase, searchPath, len(filteredResults))
+	}
+
+	for _, result := range filteredResults {
+		if detailFlag {
+			size := result.Size
+			if humanFlag {
+				// Convert size to int64 for formatting
+				if sizeInt, err := strconv.ParseInt(result.Size, 10, 64); err == nil {
+					size = formatSize(sizeInt)
+				}
+			}
+
+			fmt.Printf("%s %s", result.ID, size)
+			if result.Kind == "drive#file" {
+				fmt.Printf(" %s %s", result.ModifiedTime.Format("2006-01-02 15:04:05"), result.Path)
+			} else {
+				fmt.Printf(" %s %s (folder)", result.ModifiedTime.Format("2006-01-02 15:04:05"), result.Path)
+			}
+		} else {
+			fmt.Print(result.Path)
+		}
+		fmt.Printf("\n")
+	}
+}
+
+// Human readable file size formatting
+func formatSize(bytes int64) string {
+	const unit = 1024
+	if bytes < unit {
+		return fmt.Sprintf("%d B", bytes)
+	}
+	div, exp := int64(unit), 0
+	for n := bytes / unit; n >= unit; n /= unit {
+		div *= unit
+		exp++
+	}
+	return fmt.Sprintf("%.1f %cB", float64(bytes)/float64(div), "KMGTPE"[exp])
+}

--- a/cli/root.go
+++ b/cli/root.go
@@ -7,6 +7,7 @@ import (
 	del "github.com/52funny/pikpakcli/cli/del"
 	"github.com/52funny/pikpakcli/cli/download"
 	"github.com/52funny/pikpakcli/cli/empty"
+	"github.com/52funny/pikpakcli/cli/find"
 	"github.com/52funny/pikpakcli/cli/list"
 	"github.com/52funny/pikpakcli/cli/new"
 	"github.com/52funny/pikpakcli/cli/quota"
@@ -58,6 +59,7 @@ func init() {
 	rootCmd.AddCommand(empty.EmptyCmd)
 	rootCmd.AddCommand(rubbish.RubbishCmd)
 	rootCmd.AddCommand(rename.RenameCmd)
+	rootCmd.AddCommand(find.FindCmd)
 	rootCmd.AddCommand(shellCmd)
 }
 

--- a/cli/upload/upload.go
+++ b/cli/upload/upload.go
@@ -46,6 +46,10 @@ var UploadCmd = &cobra.Command{
 				}
 			}
 		}()
+		if len(args) == 0 {
+			cmd.Help()
+			return
+		}
 		for _, v := range args {
 			v = utils.ExpandLocalPath(v)
 			stat, err := os.Stat(v)

--- a/internal/api/file.go
+++ b/internal/api/file.go
@@ -306,3 +306,164 @@ START:
 
 	return nil
 }
+
+// Search Result Structure
+type SearchResult struct {
+	ID             string    `json:"id"`
+	Name           string    `json:"name"`
+	Kind           string    `json:"kind"`
+	Size           string    `json:"size"`
+	Hash           string    `json:"hash"`
+	CreatedTime    time.Time `json:"created_time"`
+	ModifiedTime   time.Time `json:"modified_time"`
+	ThumbnailLink  string    `json:"thumbnail_link"`
+	WebContentLink string    `json:"web_content_link"`
+	ParentID       string    `json:"parent_id"`
+	UserID         string    `json:"user_id"`
+	Path           string    `json:"path"`
+}
+
+// Search API Response
+type SearchResponse struct {
+	NextPageToken string         `json:"next_page_token"`
+	Files         []SearchResult `json:"files"`
+}
+
+// Search File by name recursively
+func (p *PikPak) SearchFiles(phrase string, limit int) ([]SearchResult, error) {
+	// If empty
+	if phrase == "" {
+		return nil, errors.New("search phrase cannot be empty")
+	}
+
+	var results []SearchResult
+	err := p.searchFilesRecursive("/", phrase, &results, limit)
+	if err != nil {
+		return nil, err
+	}
+
+	return results, nil
+}
+
+// Search files in a specific path, no recursive for performance
+func (p *PikPak) SearchFilesInPath(phrase string, targetPath string, limit int) ([]SearchResult, error) {
+	// If empty
+	if phrase == "" {
+		return nil, errors.New("search phrase cannot be empty")
+	}
+
+	parentID, err := p.GetPathFolderId(targetPath)
+	if err != nil {
+		return nil, err
+	}
+
+	files, err := p.GetFolderFileStatList(parentID)
+	if err != nil {
+		return nil, err
+	}
+
+	var results []SearchResult
+	count := 0
+
+	for _, file := range files {
+		if limit > 0 && count >= limit {
+			break
+		}
+
+		// Check if filename matches the search phrase (case-insensitive)
+		if strings.Contains(strings.ToLower(file.Name), strings.ToLower(phrase)) {
+			filePath := targetPath
+			if filePath != "/" {
+				filePath = filePath + "/" + file.Name
+			} else {
+				filePath = "/" + file.Name
+			}
+			results = append(results, SearchResult{
+				ID:            file.ID,
+				Name:          file.Name,
+				Kind:          file.Kind,
+				Size:          file.Size,
+				Hash:          file.Hash,
+				CreatedTime:   file.CreatedTime,
+				ModifiedTime:  file.ModifiedTime,
+				ThumbnailLink: file.ThumbnailLink,
+				ParentID:      file.ParentID,
+				UserID:        file.UserID,
+				Path:          filePath,
+			})
+			count++
+		}
+	}
+
+	return results, nil
+}
+
+// Recursively searches for files matching the phrase
+/* TODO
+I implement using given methods in this project
+I cannot find the API for searching files, therefore implementing using recursive traversal
+If search API is available, this implementation should be replaced */
+func (p *PikPak) searchFilesRecursive(parentPath string, phrase string, results *[]SearchResult, limit int) error {
+	if limit > 0 && len(*results) >= limit {
+		return nil
+	}
+
+	parentID, err := p.GetPathFolderId(parentPath)
+	if err != nil {
+		return err
+	}
+
+	files, err := p.GetFolderFileStatList(parentID)
+	if err != nil {
+		return err
+	}
+
+	for _, file := range files {
+		if limit > 0 && len(*results) >= limit {
+			break
+		}
+
+		// Check if filename matches the search phrase (case-insensitive)
+		if strings.Contains(strings.ToLower(file.Name), strings.ToLower(phrase)) {
+			filePath := parentPath
+			if filePath != "/" {
+				filePath = filePath + "/" + file.Name
+			} else {
+				filePath = "/" + file.Name
+			}
+			*results = append(*results, SearchResult{
+				ID:            file.ID,
+				Name:          file.Name,
+				Kind:          file.Kind,
+				Size:          file.Size,
+				Hash:          file.Hash,
+				CreatedTime:   file.CreatedTime,
+				ModifiedTime:  file.ModifiedTime,
+				ThumbnailLink: file.ThumbnailLink,
+				ParentID:      file.ParentID,
+				UserID:        file.UserID,
+				Path:          filePath,
+			})
+		}
+
+		// Recursively search in subdirectories
+		if file.Kind == "drive#folder" {
+			if limit > 0 && len(*results) >= limit {
+				break
+			}
+			nextPath := parentPath
+			if nextPath != "/" {
+				nextPath = nextPath + "/" + file.Name
+			} else {
+				nextPath = "/" + file.Name
+			}
+			err := p.searchFilesRecursive(nextPath, phrase, results, limit)
+			if err != nil {
+				logx.Warnf("search", "failed to search in folder %s: %v", nextPath, err)
+				// Continue searching in other folders on error
+			}
+		}
+	}
+
+	return nil
+}

--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -484,6 +484,13 @@ func adaptShellArgs(rootCmd *cobra.Command, currentPath string, args []string) [
 		}
 	case "rename":
 		rest = rewritePositionalPaths(rest, currentPath, 1)
+	case "find", "f":
+		// If no flags and only one positional, treat it as search phrase and use current path
+		if !flags.hasPath && flags.positionals == 1 {
+			// Use current path if only one positional argument and no path flag
+			// Only in shell as command-line usage default is root, explicit defined path is recommanded
+			rest = append([]string{"-p", currentPath}, rest...)
+		}
 	}
 
 	return append(append([]string{}, args[:consumed]...), rest...)

--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -460,13 +460,23 @@ func adaptShellArgs(rootCmd *cobra.Command, currentPath string, args []string) [
 		if !flags.hasPath && !flags.hasParentID && flags.positionals > 0 {
 			rest = append([]string{"-p", currentPath}, rest...)
 		}
-		// Handle glob patterns like "*" for download
-		if commandKey == "download" {
-			for i, arg := range rest {
-				if arg == "*" {
-					rest[i] = "."
+		// Handle glob patterns for upload (local paths)
+		if commandKey == "upload" {
+			expandedRest := make([]string, 0, len(rest))
+			for _, arg := range rest {
+				if strings.Contains(arg, "*") {
+					// Expand glob pattern for local files
+					matches, err := filepath.Glob(utils.ExpandLocalPath(arg))
+					if err == nil && len(matches) > 0 {
+						expandedRest = append(expandedRest, matches...)
+					} else {
+						expandedRest = append(expandedRest, arg)
+					}
+				} else {
+					expandedRest = append(expandedRest, arg)
 				}
 			}
+			rest = expandedRest
 		}
 	case "delete":
 		if !flags.hasPath {

--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -457,7 +457,7 @@ func adaptShellArgs(rootCmd *cobra.Command, currentPath string, args []string) [
 		}
 	case "download", "share", "upload", "new folder", "new url", "new sha":
 		rest = rewritePathFlagValues(rest, currentPath)
-		if !flags.hasPath && !flags.hasParentID {
+		if flags.hasPath || flags.hasParentID || flags.positionals > 0 {
 			rest = append([]string{"-p", currentPath}, rest...)
 		}
 	case "delete":

--- a/internal/shell/shell.go
+++ b/internal/shell/shell.go
@@ -457,8 +457,16 @@ func adaptShellArgs(rootCmd *cobra.Command, currentPath string, args []string) [
 		}
 	case "download", "share", "upload", "new folder", "new url", "new sha":
 		rest = rewritePathFlagValues(rest, currentPath)
-		if flags.hasPath || flags.hasParentID || flags.positionals > 0 {
+		if !flags.hasPath && !flags.hasParentID && flags.positionals > 0 {
 			rest = append([]string{"-p", currentPath}, rest...)
+		}
+		// Handle glob patterns like "*" for download
+		if commandKey == "download" {
+			for i, arg := range rest {
+				if arg == "*" {
+					rest[i] = "."
+				}
+			}
 		}
 	case "delete":
 		if !flags.hasPath {

--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -454,6 +454,7 @@ func TestAdaptShellArgs(t *testing.T) {
 		{name: "download keeps trailing dot as positional target", args: []string{"download", "-g", "episode.mkv", "."}, want: []string{"download", "-p", "/Movies", "-g", "episode.mkv", "."}},
 		{name: "share injects current path", args: []string{"share", "episode.mkv"}, want: []string{"share", "-p", "/Movies", "episode.mkv"}},
 		{name: "upload injects current path", args: []string{"upload", "local.file"}, want: []string{"upload", "-p", "/Movies", "local.file"}},
+		{name: "upload supports glob star", args: []string{"upload", "*"}, want: []string{"upload", "-p", "/Movies", "open.go", "shell.go", "shell_test.go"}},
 		{name: "delete rewrites relative args", args: []string{"delete", "a", "b/c"}, want: []string{"delete", "/Movies/a", "/Movies/b/c"}},
 		{name: "rm alias rewrites relative args", args: []string{"rm", "a", "b/c"}, want: []string{"rm", "/Movies/a", "/Movies/b/c"}},
 		{name: "rename rewrites first arg only", args: []string{"rename", "old.txt", "new.txt"}, want: []string{"rename", "/Movies/old.txt", "new.txt"}},

--- a/internal/shell/shell_test.go
+++ b/internal/shell/shell_test.go
@@ -448,6 +448,7 @@ func TestAdaptShellArgs(t *testing.T) {
 		{name: "ls rewrites relative arg", args: []string{"ls", "Kids"}, want: []string{"ls", "/Movies/Kids"}},
 		{name: "empty rewrites relative arg", args: []string{"empty", "Kids"}, want: []string{"empty", "/Movies/Kids"}},
 		{name: "rubbish keeps local rules path and rewrites remote root", args: []string{"rubbish", "--rules", "~/Library/Application Support/pikpakcli/rules/rubbish_rules.txt", "/"}, want: []string{"rubbish", "--rules", "~/Library/Application Support/pikpakcli/rules/rubbish_rules.txt", "/"}},
+		{name: "download no args doesn't inject current path", args: []string{"download"}, want: []string{"download"}},
 		{name: "download injects current path", args: []string{"download", "episode.mkv"}, want: []string{"download", "-p", "/Movies", "episode.mkv"}},
 		{name: "download rewrites relative path flag", args: []string{"download", "-p", "Kids", "episode.mkv"}, want: []string{"download", "-p", "/Movies/Kids", "episode.mkv"}},
 		{name: "download keeps trailing dot as positional target", args: []string{"download", "-g", "episode.mkv", "."}, want: []string{"download", "-p", "/Movies", "-g", "episode.mkv", "."}},


### PR DESCRIPTION
添加了在盘里搜索文件的功能。
支持flag：
- -d / --detail 长格式，文件具体信息
- -h / --help 帮助
- -H / --human 文件大小人类可读
- -l / --limit int 最多返回的文件数量
- -p / --path 指定搜索路径
- -r / --recursive 递归搜索（默认非递归，在指定文件夹搜索）

当前实现基于项目中已有的 API。

在查找过程中未发现明确的搜索接口，尝试过使用以下接口：
https://api-drive.mypikpak.com/phrase/v1/content/list?type=share&phrase=
但该接口未返回预期结果。

功能实现了但是如果有直接定义的api请帮我替换一下谢谢。