### PR TITLE
feat(download): 支持按时间范围下载视频片段

### DIFF
--- a/cli/download/download.go
+++ b/cli/download/download.go
@@ -3,6 +3,7 @@ package download
 import (
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
@@ -65,6 +66,13 @@ var output string
 // default false
 var progress bool
 
+// Time range
+//
+// default empty, download the whole file
+var timeRangeSpec string
+
+var clipper timeClipper = ffmpegClipper{}
+
 type warpFile struct {
 	f      *api.File
 	output string
@@ -83,6 +91,7 @@ func init() {
 	DownloadCmd.Flags().StringVarP(&folder, "path", "p", "/", "specific the base path on the pikpak server")
 	DownloadCmd.Flags().StringVarP(&parentId, "parent-id", "P", "", "the parent path id")
 	DownloadCmd.Flags().BoolVarP(&progress, "progress", "g", false, "show download progress")
+	DownloadCmd.Flags().StringVar(&timeRangeSpec, "time-range", "", "download a time range from a single video file, for example 10-20 or 01:02-01:30")
 }
 
 type downloadTargetResolver interface {
@@ -95,6 +104,11 @@ func handleDownload(cmd *cobra.Command, p *api.PikPak, args []string) {
 	if err := utils.CreateDirIfNotExist(output); err != nil {
 		fmt.Println("Create output directory failed")
 		logx.Error(err)
+		return
+	}
+
+	if strings.TrimSpace(timeRangeSpec) != "" {
+		downloadTimeRangeTarget(p, args)
 		return
 	}
 
@@ -119,6 +133,154 @@ func requiresExplicitOutputFlag(cmd *cobra.Command, args []string) bool {
 		}
 	}
 	return false
+}
+
+func downloadTimeRangeTarget(p *api.PikPak, args []string) {
+	if len(args) != 1 {
+		fmt.Println("Time range download requires exactly one file target")
+		return
+	}
+
+	timeRange, err := parseTimeRangeSpec(timeRangeSpec)
+	if err != nil {
+		fmt.Println("Parse time range failed:", err)
+		return
+	}
+
+	stat, err := resolveDownloadTarget(p, args[0])
+	if err != nil {
+		target := remoteTargetPath(args[0])
+		fmt.Println("Resolve download target failed:", target)
+		logx.Error(err)
+		return
+	}
+	if stat.Kind == api.FileKindFolder {
+		fmt.Println("Time range download only supports file targets")
+		return
+	}
+
+	file := mustGetFile(p, stat)
+	sourceURL := mediaClipSourceURL(file)
+	if sourceURL == "" {
+		fmt.Println("Time range download failed: file has no playable media URL")
+		return
+	}
+
+	path := filepath.Join(output, timeRangeOutputName(file.Name, timeRange))
+	if err := clipper.Clip(sourceURL, timeRange, path); err != nil {
+		fmt.Println("Time range download failed:", file.Name)
+		logx.Error(err)
+		return
+	}
+	fmt.Println("Download", file.Name, "Success")
+}
+
+type TimeRange struct {
+	Start string
+	End   string
+}
+
+type timeClipper interface {
+	Clip(sourceURL string, timeRange TimeRange, outputPath string) error
+}
+
+type ffmpegClipper struct{}
+
+func (ffmpegClipper) Clip(sourceURL string, timeRange TimeRange, outputPath string) error {
+	ffmpegPath, err := exec.LookPath("ffmpeg")
+	if err != nil {
+		return fmt.Errorf("ffmpeg is required for --time-range; install ffmpeg and make sure it is in PATH")
+	}
+
+	args := []string{
+		"-y",
+		"-ss", timeRange.Start,
+	}
+	if timeRange.End != "" {
+		args = append(args, "-to", timeRange.End)
+	}
+	args = append(args, "-i", sourceURL, "-c", "copy", outputPath)
+
+	cmd := exec.Command(ffmpegPath, args...)
+	output, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("ffmpeg failed: %w: %s", err, strings.TrimSpace(string(output)))
+	}
+	return nil
+}
+
+func parseTimeRangeSpec(spec string) (TimeRange, error) {
+	trimmed := strings.TrimSpace(spec)
+	if trimmed == "" {
+		return TimeRange{}, fmt.Errorf("time range must not be empty")
+	}
+
+	parts := strings.Split(trimmed, "-")
+	if len(parts) != 2 {
+		return TimeRange{}, fmt.Errorf("time range must be START-END or START-")
+	}
+	if strings.TrimSpace(parts[0]) == "" {
+		return TimeRange{}, fmt.Errorf("time range start must not be empty")
+	}
+
+	start := strings.TrimSpace(parts[0])
+	end := strings.TrimSpace(parts[1])
+	if err := validateTimePoint(start); err != nil {
+		return TimeRange{}, fmt.Errorf("invalid time range start: %w", err)
+	}
+	if end != "" {
+		if err := validateTimePoint(end); err != nil {
+			return TimeRange{}, fmt.Errorf("invalid time range end: %w", err)
+		}
+	}
+	return TimeRange{Start: start, End: end}, nil
+}
+
+func validateTimePoint(value string) error {
+	if value == "" {
+		return fmt.Errorf("time point must not be empty")
+	}
+	for _, part := range strings.Split(value, ":") {
+		if part == "" {
+			return fmt.Errorf("time point contains an empty component")
+		}
+		n, err := strconv.ParseInt(part, 10, 64)
+		if err != nil || n < 0 {
+			return fmt.Errorf("time point components must be non-negative integers")
+		}
+	}
+	return nil
+}
+
+func mediaClipSourceURL(file *api.File) string {
+	for _, media := range file.Medias {
+		if media.IsDefault && media.IsVisible && strings.TrimSpace(media.Link.URL) != "" {
+			return media.Link.URL
+		}
+	}
+	for _, media := range file.Medias {
+		if media.IsVisible && strings.TrimSpace(media.Link.URL) != "" {
+			return media.Link.URL
+		}
+	}
+	for _, media := range file.Medias {
+		if strings.TrimSpace(media.Link.URL) != "" {
+			return media.Link.URL
+		}
+	}
+	return strings.TrimSpace(file.Links.ApplicationOctetStream.URL)
+}
+
+func timeRangeOutputName(name string, timeRange TimeRange) string {
+	ext := filepath.Ext(name)
+	base := strings.TrimSuffix(name, ext)
+	suffix := strings.ReplaceAll(timeRange.Start, ":", "-") + "-"
+	if timeRange.End != "" {
+		suffix += strings.ReplaceAll(timeRange.End, ":", "-")
+	} else {
+		suffix += "end"
+	}
+	return base + "." + suffix + ext
 }
 
 func downloadTarget(p *api.PikPak, arg string) {

--- a/cli/download/download_test.go
+++ b/cli/download/download_test.go
@@ -4,6 +4,7 @@ import (
 	"errors"
 	"path/filepath"
 	"testing"
+	"time"
 
 	"github.com/52funny/pikpakcli/internal/api"
 	"github.com/spf13/cobra"
@@ -139,4 +140,83 @@ func TestRequiresExplicitOutputFlag(t *testing.T) {
 
 	require.NoError(t, cmd.Flags().Set("output", "."))
 	require.False(t, requiresExplicitOutputFlag(cmd, []string{"file.txt", "."}))
+}
+
+func TestParseTimeRangeSpec(t *testing.T) {
+	closed, err := parseTimeRangeSpec("10-20")
+	require.NoError(t, err)
+	require.Equal(t, "10", closed.Start)
+	require.Equal(t, "20", closed.End)
+
+	openEnded, err := parseTimeRangeSpec("01:02-")
+	require.NoError(t, err)
+	require.Equal(t, "01:02", openEnded.Start)
+	require.Empty(t, openEnded.End)
+}
+
+func TestParseTimeRangeSpecRejectsInvalidValues(t *testing.T) {
+	for _, spec := range []string{"", "-10", "10", "a-10", "10-b", "10-20-30", "01::02-03:04"} {
+		_, err := parseTimeRangeSpec(spec)
+		require.Error(t, err, spec)
+	}
+}
+
+func TestTimeRangeOutputName(t *testing.T) {
+	require.Equal(t, "movie.10-20.mp4", timeRangeOutputName("movie.mp4", TimeRange{Start: "10", End: "20"}))
+	require.Equal(t, "movie.01-02-end.mkv", timeRangeOutputName("movie.mkv", TimeRange{Start: "01:02"}))
+}
+
+func TestMediaClipSourceURLPrefersDefaultVisibleMedia(t *testing.T) {
+	file := &api.File{}
+	file.Links.ApplicationOctetStream.URL = "https://example.com/original"
+	file.Medias = []struct {
+		MediaID   string      `json:"media_id"`
+		MediaName string      `json:"media_name"`
+		Video     interface{} `json:"video"`
+		Link      struct {
+			URL    string    `json:"url"`
+			Token  string    `json:"token"`
+			Expire time.Time `json:"expire"`
+		} `json:"link"`
+		NeedMoreQuota  bool          `json:"need_more_quota"`
+		VipTypes       []interface{} `json:"vip_types"`
+		RedirectLink   string        `json:"redirect_link"`
+		IconLink       string        `json:"icon_link"`
+		IsDefault      bool          `json:"is_default"`
+		Priority       int           `json:"priority"`
+		IsOrigin       bool          `json:"is_origin"`
+		ResolutionName string        `json:"resolution_name"`
+		IsVisible      bool          `json:"is_visible"`
+		Category       string        `json:"category"`
+	}{
+		{
+			Link: struct {
+				URL    string    `json:"url"`
+				Token  string    `json:"token"`
+				Expire time.Time `json:"expire"`
+			}{URL: "https://example.com/visible"},
+			IsVisible: true,
+		},
+		{
+			Link: struct {
+				URL    string    `json:"url"`
+				Token  string    `json:"token"`
+				Expire time.Time `json:"expire"`
+			}{URL: "https://example.com/default"},
+			IsDefault: true,
+			IsVisible: true,
+		},
+	}
+
+	require.Equal(t, "https://example.com/default", mediaClipSourceURL(file))
+}
+
+func TestFFmpegClipperReportsMissingFFmpeg(t *testing.T) {
+	t.Setenv("PATH", "")
+
+	err := ffmpegClipper{}.Clip("https://example.com/video.mp4", TimeRange{Start: "0", End: "10"}, filepath.Join(t.TempDir(), "clip.mp4"))
+
+	require.Error(t, err)
+	require.Contains(t, err.Error(), "ffmpeg is required for --time-range")
+	require.Contains(t, err.Error(), "install ffmpeg")
 }

--- a/docs/command.md
+++ b/docs/command.md
@@ -71,6 +71,13 @@
   pikpakcli download -p Movies -o Film -g
   ```
 
+- Download a time range from a single video file. This requires `ffmpeg` to be installed and available in `PATH`.
+
+  ```bash
+  pikpakcli download --time-range 10-20 -p Movies Peppa_Pig.mp4 -o Film
+  pikpakcli download --time-range 01:02-01:30 -p Movies/Peppa_Pig.mp4 -o Film
+  ```
+
 ## Share
 
 - Share links to all files under Movies.

--- a/docs/command_zhCN.md
+++ b/docs/command_zhCN.md
@@ -68,6 +68,13 @@
   pikpakcli download -p Movies -o Film -g
   ```
 
+- 下载单个视频文件的指定时间范围。该功能需要安装 `ffmpeg`，并确保 `ffmpeg` 在 `PATH` 中。
+
+  ```bash
+  pikpakcli download --time-range 10-20 -p Movies Peppa_Pig.mp4 -o Film
+  pikpakcli download --time-range 01:02-01:30 -p Movies/Peppa_Pig.mp4 -o Film
+  ```
+
 ## 分享
 
 - 分享 Movies 下的所有文件的链接


### PR DESCRIPTION
这个 PR 给 `download` 命令增加了 `--time-range` 参数，用于下载单个视频文件的一段内容。

示例：

```bash
pikpakcli download --time-range 10-20 -p Movies video.mp4 -o clips
pikpakcli download --time-range 01:02-01:30 -p Movies/video.mp4 -o clips
```

该功能适合只需要截取视频中一小段内容的场景，不需要先下载完整文件。

实现上使用 `ffmpeg -c copy` 处理远程媒体 URL。`ffmpeg` 是可选运行时依赖：普通下载不受影响，只有使用 `--time-range` 时才需要。如果本机没有安装 `ffmpeg`，命令会提示：

```text
ffmpeg is required for --time-range; install ffmpeg and make sure it is in PATH
```

行为限制：

- 只支持单个文件目标。
- 不支持文件夹和多个下载目标。
- 优先使用 `medias[]` 中默认可见的播放 URL；没有可用媒体 URL 时，回退到原始下载 URL。
- 输出文件名会附带时间范围，例如 `video.10-20.mp4`、`video.01-02-01-30.mp4`。
- 由于使用 stream copy，裁剪边界可能受关键帧影响。

已补充单元测试，覆盖：

- `--time-range` 参数解析
- 输出文件名生成
- 媒体 URL 选择
- 缺少 `ffmpeg` 时的错误提示

验证：

```bash
go test ./...
```

另外在 Linux 平台用真实 PikPak 视频做过手动测试：

```bash
pikpakcli download --time-range 0-10 -p '<video-path>' . -o range-test
```

命令成功下载了 10 秒的视频片段，输出文件可以正常播放。
